### PR TITLE
Set baseUrl to allow absolute path linking for built items

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-# baseURL = "http://example.org/"
+baseURL = "/"
 languageCode = "en-us"
 title = "what is..."
 theme = "ananke"


### PR DESCRIPTION
## purpose

pages `definition` and `code of conduct` navbar links do not redirect to the index page

## What you did

Hugo has a [setting](baseURL) for this and local testing shows that this shouldn't have any regressions.